### PR TITLE
Added use of chain rule in pytorch examples.

### DIFF
--- a/bindings/python/examples/pytorch_loss.py
+++ b/bindings/python/examples/pytorch_loss.py
@@ -99,7 +99,7 @@ class GTNLossFunction(torch.autograd.Function):
         # Compute gradients in parallel over the batch:
         gtn.parallel_for(backward_single, range(B))
 
-        return input_grad.to(grad_output.device), None
+        return grad_output.unsqueeze(1).unsqueeze(1) * input_grad.to(grad_output.device), None
 
 
 # make an alias for the loss function:

--- a/docs/source/pytorch.rst
+++ b/docs/source/pytorch.rst
@@ -117,5 +117,5 @@ each ``loss`` graph and accumulating the gradients into a
         # Compute gradients in parallel over the batch:
         gtn.parallel_for(backward_single, range(B))
 
-        return input_grad.to(grad_output.device), None
+        return grad_output.unsqueeze(1).unsqueeze(1) * input_grad.to(grad_output.device), None
 


### PR DESCRIPTION
Hi! I noticed that the python example and docs for interfacing with pytorch didn't make use of the chain rule, which led to wrong gradients when you do things downstream with the loss.